### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 # TyraCraft (Alpha version)
 
-It's an Minecraft for Play Station 2 built with Tyra Engine!
+It's Minecraft for the Play Station 2 built with Tyra Engine!
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 # TyraCraft (Alpha version)
 
-It's Minecraft for the Play Station 2 built with Tyra Engine!
+It's Minecraft for the PlayStation 2 built with Tyra Engine!
 
 ## Getting Started
 


### PR DESCRIPTION
Fixed the typo of issue #13 from
`It's an Minecraft for Play Station 2 built with Tyra Engine!`
to
`It's Minecraft for the PlayStation 2 built with Tyra Engine!`