### PR TITLE
docs: fix PS2DEV environment typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It's a voxel like game for Play Station 2 built with Tyra Engine!
 ### Prerequisites
 
 - Tyra environment - [Tyra](https://github.com/H4570/tyra)
-- PS2DEV enviroment - [PS2DEV](https://github.com/ps2dev/ps2dev)
+- PS2DEV environment - [PS2DEV](https://github.com/ps2dev/ps2dev)
 - PS2 Emulator [PCSX2](https://pcsx2.net/) or [PS2Link](https://github.com/ps2dev/ps2link) for a real PS2
 
 


### PR DESCRIPTION
## Summary
- correct the PS2DEV prerequisite spelling from `enviroment` to `environment` in the README

Fixes #13.

## Validation
- `rg -n "enviroment|environment|PS2DEV" README.md`
- `git diff --check`

No runtime tests were run because this is a README-only spelling fix.